### PR TITLE
Chore/husky-migration: Migrate to v9 husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged
 
 yarn test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,3 @@
-#!/usr/bin/env sh
-
-. "$(dirname -- "$0")/_/husky.sh"
-
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 PROTECTED_BRANCHES="^(master)"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "scripts": {
-    "postinstall": "husky install",
+    "postinstall": "husky",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
- Remove install from husky post install command
- Remove set path related command lines
- You can see change log below https://github.com/typicode/husky/releases/tag/v9.0.1